### PR TITLE
Develop

### DIFF
--- a/config/env/test.exs
+++ b/config/env/test.exs
@@ -1,8 +1,9 @@
 use Mix.Config
 
-config :spur, ecto_repos: [SpurTest.Repo],
-              repo: SpurTest.Repo,
-              audience_module: SpurTest.AppUser
+config :spur,
+  ecto_repos: [SpurTest.Repo],
+  repo: SpurTest.Repo,
+  audience_module: SpurTest.AppUser
 
 config :spur, SpurTest.Repo,
   adapter: Ecto.Adapters.Postgres,

--- a/lib/spur/activity.ex
+++ b/lib/spur/activity.ex
@@ -5,12 +5,12 @@ defmodule Spur.Activity do
 
   alias Spur.Activity
 
-  schema "activities" do
-    field :action, :string
-    field :actor, :string
-    field :object, :string, default: nil
-    field :target, :string, default: nil
-    field :meta, :map, default: %{}
+  schema "activity" do
+    field(:action, :string)
+    field(:actor, :string)
+    field(:object, :string, default: nil)
+    field(:target, :string, default: nil)
+    field(:meta, :map, default: %{})
 
     timestamps(updated_at: false)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -41,23 +41,23 @@ defmodule Spur.MixProject do
   end
 
   defp package do
-   %{
-     name: :spur,
-     files: ["lib", "mix.exs", "README*"],
-     maintainers: [
-       "T. Floyd Wright",
-     ],
-     licenses: ["Apache License 2.0"],
-     links: %{
-       "GitHub" => "https://github.com/tfwright/spur"
-     }
-   }
- end
+    %{
+      name: :spur,
+      files: ["lib", "mix.exs", "README*"],
+      maintainers: [
+        "T. Floyd Wright"
+      ],
+      licenses: ["Apache License 2.0"],
+      links: %{
+        "GitHub" => "https://github.com/tfwright/spur"
+      }
+    }
+  end
 
- def docs do
-   [main: "Spur"]
- end
+  def docs do
+    [main: "Spur"]
+  end
 
- defp elixirc_paths(:test), do: ["lib", "test/support"]
- defp elixirc_paths(_), do: ["lib"]
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/priv/test/migrations/20190429181331_add_activities.exs
+++ b/priv/test/migrations/20190429181331_add_activities.exs
@@ -7,6 +7,7 @@ defmodule SpurTest.Repo.Migrations.AddActivities do
       add(:actor, :string)
       add(:object, :string)
       add(:meta, :map)
+      add(:target, :string)
 
       timestamps(updated_at: false)
     end

--- a/priv/test/migrations/20190429181331_add_activities.exs
+++ b/priv/test/migrations/20190429181331_add_activities.exs
@@ -2,11 +2,11 @@ defmodule SpurTest.Repo.Migrations.AddActivities do
   use Ecto.Migration
 
   def change do
-    create table(:activities) do
-      add :action, :string, null: false
-      add :actor, :string
-      add :object, :string
-      add :meta, :map
+    create table(:activity) do
+      add(:action, :string, null: false)
+      add(:actor, :string)
+      add(:object, :string)
+      add(:meta, :map)
 
       timestamps(updated_at: false)
     end

--- a/priv/test/migrations/20190430204243_add_activities_users_join_table.exs
+++ b/priv/test/migrations/20190430204243_add_activities_users_join_table.exs
@@ -3,8 +3,8 @@ defmodule SpurTest.Repo.Migrations.AddActivitiesUsersJoinTable do
 
   def change do
     create table(:activities_users) do
-      add :activity_id, references(:activities)
-      add :user_id, references(:app_users)
+      add(:activity_id, references(:activity))
+      add(:user_id, references(:app_users))
     end
   end
 end

--- a/priv/test/migrations/20190502230715_add_app_users_trackable_structs_join_table.exs
+++ b/priv/test/migrations/20190502230715_add_app_users_trackable_structs_join_table.exs
@@ -3,8 +3,8 @@ defmodule SpurTest.Repo.Migrations.AddAppUsersTrackableStructsJoinTable do
 
   def change do
     create table(:app_users_trackable_structs) do
-      add :trackable_struct_id, references(:trackable_structs)
-      add :user_id, references(:app_users)
+      add(:trackable_struct_id, references(:trackable_structs))
+      add(:user_id, references(:app_users))
     end
   end
 end

--- a/test/spur_test.exs
+++ b/test/spur_test.exs
@@ -39,7 +39,8 @@ defmodule SpurTest do
       user = Repo.insert!(%AppUser{})
       test_trackable = %TrackableStruct{user: user}
 
-      assert {:error, _trackable} = Spur.insert(test_trackable, fn _, p -> Map.merge(p, %{actor: nil}) end)
+      assert {:error, _trackable} =
+               Spur.insert(test_trackable, fn _, p -> Map.merge(p, %{actor: nil}) end)
     end
 
     test "returns the object" do
@@ -59,14 +60,15 @@ defmodule SpurTest do
 
     test "associates with audience" do
       user = Repo.insert!(%AppUser{})
-      test_trackable = %TrackableStruct{user: user} |> Repo.insert!
+      test_trackable = %TrackableStruct{user: user} |> Repo.insert!()
 
       watcher = Repo.insert!(%AppUser{})
+
       test_trackable
       |> Repo.preload(:watchers)
-      |> Ecto.Changeset.change
+      |> Ecto.Changeset.change()
       |> Ecto.Changeset.put_assoc(:watchers, [watcher])
-      |> Repo.update!
+      |> Repo.update!()
 
       changeset = Ecto.Changeset.change(test_trackable)
 
@@ -79,7 +81,7 @@ defmodule SpurTest do
   describe "update/1" do
     test "reponds with ok status" do
       user = Repo.insert!(%AppUser{})
-      test_trackable = %TrackableStruct{user: user} |> Repo.insert!
+      test_trackable = %TrackableStruct{user: user} |> Repo.insert!()
 
       changeset = Ecto.Changeset.change(test_trackable)
 
@@ -88,7 +90,7 @@ defmodule SpurTest do
 
     test "returns the object" do
       user = Repo.insert!(%AppUser{})
-      test_trackable = %TrackableStruct{user: user} |> Repo.insert!
+      test_trackable = %TrackableStruct{user: user} |> Repo.insert!()
 
       changeset = Ecto.Changeset.change(test_trackable)
 
@@ -97,7 +99,7 @@ defmodule SpurTest do
 
     test "inserts the trace" do
       user = Repo.insert!(%AppUser{})
-      test_trackable = %TrackableStruct{user: user} |> Repo.insert!
+      test_trackable = %TrackableStruct{user: user} |> Repo.insert!()
 
       changeset = Ecto.Changeset.change(test_trackable)
 
@@ -110,30 +112,30 @@ defmodule SpurTest do
   describe "delete/1" do
     test "reponds with ok status" do
       user = Repo.insert!(%AppUser{})
-      test_trackable = %TrackableStruct{user: user} |> Repo.insert!
+      test_trackable = %TrackableStruct{user: user} |> Repo.insert!()
 
       assert {:ok, _trackable} = Spur.delete(test_trackable)
     end
 
     test "deletes the object" do
       user = Repo.insert!(%AppUser{})
-      test_trackable = %TrackableStruct{user: user} |> Repo.insert!
+      test_trackable = %TrackableStruct{user: user} |> Repo.insert!()
 
       assert {:ok, _trackable} = Spur.delete(test_trackable)
 
-      assert 0 = TrackableStruct |>  Repo.aggregate(:count, :id)
+      assert 0 = TrackableStruct |> Repo.aggregate(:count, :id)
     end
 
     test "returns the object" do
       user = Repo.insert!(%AppUser{})
-      test_trackable = %TrackableStruct{user: user} |> Repo.insert!
+      test_trackable = %TrackableStruct{user: user} |> Repo.insert!()
 
       assert {_status, test_trackable} = Spur.delete(test_trackable)
     end
 
     test "inserts the trace" do
       user = Repo.insert!(%AppUser{})
-      test_trackable = %TrackableStruct{user: user} |> Repo.insert!
+      test_trackable = %TrackableStruct{user: user} |> Repo.insert!()
 
       {:ok, _test_trackable} = Spur.delete(test_trackable)
 

--- a/test/support/app_user.ex
+++ b/test/support/app_user.ex
@@ -2,12 +2,14 @@ defmodule SpurTest.AppUser do
   use Ecto.Schema
 
   schema "app_users" do
-    field :name, :string
+    field(:name, :string)
 
-    has_many :trackable_structs, SpurTest.TrackableStruct, foreign_key: :user_id
+    has_many(:trackable_structs, SpurTest.TrackableStruct, foreign_key: :user_id)
 
-    many_to_many :activities, Spur.Activity, join_through: "activities_users",
-                                             join_keys: [user_id: :id, activity_id: :id]
+    many_to_many(:activities, Spur.Activity,
+      join_through: "activities_users",
+      join_keys: [user_id: :id, activity_id: :id]
+    )
 
     timestamps()
   end

--- a/test/support/repo.ex
+++ b/test/support/repo.ex
@@ -1,4 +1,5 @@
 defmodule SpurTest.Repo do
-  use Ecto.Repo, otp_app: :spur,
-                 adapter: Ecto.Adapters.Postgres
+  use Ecto.Repo,
+    otp_app: :spur,
+    adapter: Ecto.Adapters.Postgres
 end

--- a/test/support/trackable_struct.ex
+++ b/test/support/trackable_struct.ex
@@ -2,10 +2,12 @@ defmodule SpurTest.TrackableStruct do
   use Ecto.Schema
 
   schema "trackable_structs" do
-    belongs_to :user, SpurTest.AppUser
+    belongs_to(:user, SpurTest.AppUser)
 
-    many_to_many :watchers, SpurTest.AppUser, join_through: "app_users_trackable_structs",
-                                              join_keys: [trackable_struct_id: :id, user_id: :id]
+    many_to_many(:watchers, SpurTest.AppUser,
+      join_through: "app_users_trackable_structs",
+      join_keys: [trackable_struct_id: :id, user_id: :id]
+    )
 
     timestamps()
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
-{:ok, _pid} = SpurTest.Repo.start_link
+{:ok, _pid} = SpurTest.Repo.start_link()
 
 Ecto.Adapters.SQL.Sandbox.mode(SpurTest.Repo, :manual)
 


### PR DESCRIPTION
While using `spur` in one of my projects,  I found that `target` column defined in the `Spur.Acitivty` schema is missing in the `activity` table migration, which raises errors from database level while fetching activities. So I have added it to the migration file.

Also, I have formatted the entire code base using `mix format` and modified the activity table name from `activities` to `activity` to stick to the database naming conventions mentioned [here](https://stackoverflow.com/questions/7662/database-table-and-column-naming-conventions)

Feel free to contact to discuss the changes I made.