### PR TITLE
fix: added target to activities table migration

### DIFF
--- a/priv/test/migrations/20190429181331_add_activities.exs
+++ b/priv/test/migrations/20190429181331_add_activities.exs
@@ -7,7 +7,7 @@ defmodule SpurTest.Repo.Migrations.AddActivities do
       add(:actor, :string)
       add(:object, :string)
       add(:meta, :map)
-
+      add(:target, :string)
       timestamps(updated_at: false)
     end
   end


### PR DESCRIPTION
Added `target` column to activities table migration.