### PR TITLE
Feature/supporting UUID as primary key. 

### DIFF
--- a/lib/spur/activity.ex
+++ b/lib/spur/activity.ex
@@ -3,6 +3,11 @@ defmodule Spur.Activity do
 
   import Ecto.Changeset
 
+  if Application.get_env(:spur, :uuid_primary_key_enabled, false) do
+    @primary_key {:id, :binary_id, autogenerate: true}
+    @foreign_key_type :binary_id
+  end
+
   schema Application.get_env(:spur, :activities_table_name, "activities") do
     field(:action, :string)
     field(:actor, :string)

--- a/mix.exs
+++ b/mix.exs
@@ -32,8 +32,8 @@ defmodule Spur.MixProject do
   defp deps do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:ecto, "~> 3.0"},
-      {:ecto_sql, "~> 3.0", only: :test},
+      {:ecto, "~> 3.6"},
+      {:ecto_sql, "~> 3.6", only: :test},
       {:postgrex, "~> 0.14", only: :test},
       {:jason, "~> 1.0", only: :test},
       {:atomic_map, "~> 0.9"}


### PR DESCRIPTION
To make this work you have to define certain things in config.exs file

```
config :spur,
  ecto_repos: [AppName.Repo],
  repo: AppName.Repo,
  audience_module: AppName.User,
  activities_table_name: "activity",
  uuid_primary_key_enabled: true,
  audience_assoc_name: :activities
```