### PR TITLE
Allow uuid primary keys for activities table

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Basic steps are
     config :spur, repo: MyApp.Repo
     ```
 
-3. Generate and run a migration that adds an "activities" table to your repo (see priv/test/migrations). To use a different table name, set the `activities_table_name` config.
+3. Generate and run a migration that adds an "activities" table to your repo (see priv/test/migrations). To use a different table name, set the `activities_table_name` config. To use
+   `:uuid` primary key for your activities table, set the `uuid_primary_key_enabled` config to true.
 
 
 That's enough to start tracking arbitrary activities:

--- a/lib/spur/activity.ex
+++ b/lib/spur/activity.ex
@@ -3,6 +3,11 @@ defmodule Spur.Activity do
 
   import Ecto.Changeset
 
+  if Application.get_env(:spur, :uuid_primary_key_enabled, false) do
+    @primary_key {:id, :binary_id, autogenerate: true}
+    @foreign_key_type :binary_id
+  end
+
   schema Application.get_env(:spur, :activities_table_name, "activities") do
     field(:action, :string)
     field(:actor, :string)


### PR DESCRIPTION
This lets others use `spur ` in their projects even when they use `:uuid` for their primary key.